### PR TITLE
Add PPTX text extraction utility and tests

### DIFF
--- a/pptx_extraction.py
+++ b/pptx_extraction.py
@@ -1,0 +1,48 @@
+"""Utility for extracting text from PPTX files.
+
+This script provides a simple function to read a PowerPoint presentation and
+return a dictionary mapping slide numbers to lists of text found on each slide.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pptx import Presentation
+
+
+def extract_pptx_text(path: str) -> Dict[int, List[str]]:
+    """Extract all text from the presentation located at ``path``.
+
+    Parameters
+    ----------
+    path: str
+        Path to the ``.pptx`` file.
+
+    Returns
+    -------
+    Dict[int, List[str]]
+        Dictionary where keys are 1-based slide numbers and values are lists of
+        text strings found on the corresponding slide.
+    """
+    presentation = Presentation(path)
+    slides: Dict[int, List[str]] = {}
+
+    for index, slide in enumerate(presentation.slides, start=1):
+        texts: List[str] = []
+        for shape in slide.shapes:
+            if getattr(shape, "has_text_frame", False):
+                text = shape.text.strip()
+                if text:
+                    texts.append(text)
+        slides[index] = texts
+
+    return slides
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 2:
+        print("Usage: python pptx_extraction.py <path-to-pptx>")
+        raise SystemExit(1)
+    result = extract_pptx_text(sys.argv[1])
+    print(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,10 +44,12 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 Pygments==2.19.2
 PyJWT==2.10.1
+pytest==8.3.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-jose==3.5.0
 python-multipart==0.0.20
+python-pptx==0.6.22
 realtime==2.7.0
 regex==2025.7.34
 requests==2.32.4

--- a/tests/test_pptx_extraction.py
+++ b/tests/test_pptx_extraction.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pptx import Presentation
+
+from pptx_extraction import extract_pptx_text
+
+
+def _create_sample_pptx(path: Path) -> None:
+    prs = Presentation()
+    layout = prs.slide_layouts[0]
+
+    slide1 = prs.slides.add_slide(layout)
+    slide1.shapes.title.text = "Title 1"
+    slide1.placeholders[1].text = "Subtitle 1"
+
+    slide2 = prs.slides.add_slide(layout)
+    slide2.shapes.title.text = "Title 2"
+    slide2.placeholders[1].text = "Subtitle 2"
+
+    prs.save(path)
+
+
+def test_extract_pptx_text(tmp_path: Path) -> None:
+    pptx_file = tmp_path / "sample.pptx"
+    _create_sample_pptx(pptx_file)
+
+    result = extract_pptx_text(str(pptx_file))
+
+    assert result == {
+        1: ["Title 1", "Subtitle 1"],
+        2: ["Title 2", "Subtitle 2"],
+    }


### PR DESCRIPTION
## Summary
- add `pptx_extraction.py` to extract slide text into a dictionary
- test PPTX text extraction using a temporary presentation
- include `python-pptx` and `pytest` in requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c1a9477448328803e37763eb48648