### PR TITLE
Avoid blocking calls in users endpoint

### DIFF
--- a/app/api/endpoints/users.py
+++ b/app/api/endpoints/users.py
@@ -1,11 +1,18 @@
 from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from app.db.client import supabase
 
 router = APIRouter(prefix="/users", tags=["users"])
 
 @router.get("/")
 async def list_users():
-    result = supabase.table("users").select("*").execute()
+    """Return a list of users from the Supabase table."""
+
+    def fetch_users():
+        return supabase.table("users").select("*").execute()
+
+    result = await run_in_threadpool(fetch_users)
     if result.error:
-        raise HTTPException(status_code=500, detail=result.error.message)
+        message = getattr(result.error, "message", str(result.error))
+        raise HTTPException(status_code=500, detail=message)
     return result.data

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ postgrest==1.1.1
 preshed==3.0.10
 pydantic==2.11.7
 pydantic_core==2.33.2
+pydantic-settings==2.10.1
 Pygments==2.19.2
 PyJWT==2.10.1
 python-dateutil==2.9.0.post0

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
+
+os.environ.setdefault("SUPABASE_URL", "https://example.supabase.co")
+os.environ.setdefault("SUPABASE_KEY", "dummy-key")
+
+from app.db import client as db_client
+from app.api.endpoints import users as users_endpoint
+from main import app
+
+class DummyResult:
+    def __init__(self, data=None, error=None):
+        self.data = data
+        self.error = error
+
+class DummyTable:
+    def select(self, query):
+        return self
+
+    def execute(self):
+        return DummyResult(data=[{"id": 1, "name": "Alice"}])
+
+class DummySupabase:
+    def table(self, name):
+        assert name == "users"
+        return DummyTable()
+
+def test_list_users_returns_data(monkeypatch):
+    dummy_supabase = DummySupabase()
+    monkeypatch.setattr(db_client, "supabase", dummy_supabase)
+    monkeypatch.setattr(users_endpoint, "supabase", dummy_supabase)
+
+    client = TestClient(app)
+    response = client.get("/users")
+    assert response.status_code == 200
+    assert response.json() == [{"id": 1, "name": "Alice"}]


### PR DESCRIPTION
## Summary
- offload Supabase queries to a threadpool to avoid blocking the event loop
- list users endpoint now gives clearer errors
- add missing dependency and a regression test for the users endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932e9698ec832883eea43dbc0fc993