### PR TITLE
Refactor challenge generator naming to remove AI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # 🚀 Recode-Backend
 
-**Transform NWU lecture slides into interactive, NLP-driven coding exercises for semester-based gamified learning.**
+**Transform NWU lecture slides into interactive coding exercises for semester-based gamified learning.**
 
-Recode is a revolutionary educational platform that leverages natural language processing to convert traditional lecture materials into engaging, interactive coding challenges. Built with FastAPI and powered by Supabase, this backend service provides the foundation for a gamified learning experience that adapts to each student's progress.
+Recode is an educational platform that converts traditional lecture materials into engaging, interactive coding challenges. Built with FastAPI and powered by Supabase, this backend service provides the foundation for a gamified learning experience that adapts to each student's progress.
 
 
 ## 🎯 Project Overview
 
 Recode addresses the challenge of making computer science education more interactive and engaging by:
 - **Transforming static slides** into dynamic coding exercises
-- **Leveraging NLP** to understand and process educational content
+- **Summarising key points** from educational content automatically
 - **Creating gamified experiences** with semester-based progression
 - **Providing real-time feedback** and adaptive learning paths
 
@@ -130,7 +130,7 @@ The application uses the following key tables:
 
 ## 🎯 Key Features
 
-### 1. NLP Content Processing
+### 1. Automated Content Processing
 - **Slide Analysis**: Extract key concepts from lecture slides
 - **Code Generation**: Create relevant coding exercises
 - **Difficulty Scaling**: Adjust challenge complexity based on student level
@@ -169,7 +169,7 @@ The application uses the following key tables:
 - [ ] Content upload system
 
 ### Phase 2: Intelligence
-- [ ] Advanced NLP processing
+- [ ] Advanced content processing
 - [ ] Adaptive difficulty algorithms
 - [ ] Performance analytics dashboard
 

--- a/app/Core/config.py
+++ b/app/Core/config.py
@@ -32,7 +32,7 @@ class Settings:
             self.judge0_timeout_s = float(os.getenv("JUDGE0_TIMEOUT", "30"))
         except Exception:
             self.judge0_timeout_s = 30.0
-        # Hugging Face / AI generation
+        # Hugging Face content generation
         self.hf_api_token = os.getenv("HUGGINGFACE_API_TOKEN", "")
         self.hf_model_id = os.getenv("HF_MODEL_ID", "mistralai/Mistral-7B-Instruct-v0.3")
         try:

--- a/app/features/achievements/repository.py
+++ b/app/features/achievements/repository.py
@@ -1,12 +1,16 @@
-#this is all ai - to use as starting point because i dont understand this part yet (:
 from __future__ import annotations
-from typing import Optional, Dict, Any, List
-from datetime import datetime, timedelta, timezone
+
+from typing import Any, Dict, List, Optional
+
 from app.DB.supabase import get_supabase
 
+
 class AchievementsRepository:
-    #badges
+    """Data access helpers for achievements, badges, titles and Elo ratings."""
+
     async def get_badges_for_user(self, user_id: str) -> List[Dict[str, Any]]:
+        """Return all badges earned by the user."""
+
         client = await get_supabase()
         resp = (
             client.table("user_badges")
@@ -17,6 +21,8 @@ class AchievementsRepository:
         return resp.data or []
 
     async def add_badge_to_user(self, user_id: str, badge_id: str) -> Dict[str, Any]:
+        """Award a single badge to the user."""
+
         client = await get_supabase()
         resp = client.table("user_badges").insert({"user_id": user_id, "badge_id": badge_id}).execute()
         if not resp.data:
@@ -24,13 +30,16 @@ class AchievementsRepository:
         return resp.data[0]
 
     async def add_badges_batch(self, user_id: str, badge_ids: List[str]) -> List[Dict[str, Any]]:
+        """Award multiple badges to the user in a single call."""
+
         client = await get_supabase()
-        data = [{"user_id": user_id, "badge_id": b} for b in badge_ids]
+        data = [{"user_id": user_id, "badge_id": badge_id} for badge_id in badge_ids]
         resp = client.table("user_badges").insert(data).execute()
         return resp.data or []
 
-    #titles
     async def get_title_for_user(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch the active title for the user, if one exists."""
+
         client = await get_supabase()
         resp = (
             client.table("user_titles")
@@ -42,27 +51,33 @@ class AchievementsRepository:
         return resp.data or None
 
     async def award_title(self, user_id: str, title_id: str) -> Dict[str, Any]:
+        """Assign a title to the user."""
+
         client = await get_supabase()
         resp = client.table("user_titles").insert({"user_id": user_id, "title_id": title_id}).execute()
         if not resp.data:
             raise RuntimeError("Failed to award title to user")
         return resp.data[0]
-    
-    #elo
+
     async def get_user_elo(self, user_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve the Elo entry for the user."""
+
         client = await get_supabase()
         resp = client.table("user_elo").select("*").eq("user_id", user_id).single().execute()
         return resp.data or None
 
     async def update_user_elo(self, user_id: str, new_elo: int) -> Dict[str, Any]:
+        """Update the stored Elo rating."""
+
         client = await get_supabase()
         resp = client.table("user_elo").update({"elo": new_elo}).eq("user_id", user_id).execute()
         if not resp.data:
             raise RuntimeError("Failed to update user Elo")
         return resp.data[0]
 
-    #achievements aggregate
     async def get_achievements_for_user(self, user_id: str) -> Dict[str, Any]:
+        """Aggregate badges, titles and Elo for quick consumption."""
+
         badges = await self.get_badges_for_user(user_id)
         title = await self.get_title_for_user(user_id)
         elo = await self.get_user_elo(user_id)
@@ -71,5 +86,6 @@ class AchievementsRepository:
             "badges": badges,
             "title": title,
         }
+
 
 achievements_repository = AchievementsRepository()

--- a/app/features/challenges/endpoints.py
+++ b/app/features/challenges/endpoints.py
@@ -10,7 +10,7 @@ from .schemas import (
 )
 from .service import challenge_service
 from app.features.challenges.repository import challenge_repository
-from app.features.challenges.claude_generator import (
+from app.features.challenges.challenge_pack_generator import (
     generate_tier_preview,
     generate_and_save_tier,
 )

--- a/app/features/challenges/model_runtime/bedrock_client.py
+++ b/app/features/challenges/model_runtime/bedrock_client.py
@@ -22,8 +22,8 @@ bedrock = boto3.client(
 )
 
 
-async def invoke_claude(prompt: str, max_tokens: Optional[int] = None) -> Dict[str, Any]:
-    """Invoke the configured Claude model on AWS Bedrock and return a validated JSON payload."""
+async def invoke_model(prompt: str, max_tokens: Optional[int] = None) -> Dict[str, Any]:
+    """Invoke the configured Bedrock model and return a validated JSON payload."""
     if max_tokens is None:
         max_tokens = settings.bedrock_max_tokens
 
@@ -256,4 +256,4 @@ async def invoke_claude(prompt: str, max_tokens: Optional[int] = None) -> Dict[s
                     pass
         except Exception:
             pass
-        raise ValueError(f"Failed to parse Claude response: {exc}")
+        raise ValueError(f"Failed to parse model response: {exc}")

--- a/scripts/generate_and_save_test.py
+++ b/scripts/generate_and_save_test.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from app.features.challenges import claude_generator
+from app.features.challenges import challenge_pack_generator
 from app.features.challenges.templates.strings import get_fallback_payload
 
 # Fake invoke that returns fallback payloads based on the prompt (tier)
@@ -17,7 +17,7 @@ async def _fake_invoke(prompt: str):
 async def main():
     # Patch the generator module to use the fake invoke
     try:
-        claude_generator.invoke_claude = _fake_invoke
+        challenge_pack_generator.invoke_model = _fake_invoke
     except Exception:
         pass
 
@@ -27,7 +27,12 @@ async def main():
     lecturer_id = int(os.environ.get("GEN_LECTURER_ID", "1"))
 
     print(f"Running generation for week={week}, module_code={module_code}, lecturer_id={lecturer_id}")
-    gen = claude_generator.ClaudeChallengeGenerator(week, slide_stack_id=None, module_code=module_code, lecturer_id=lecturer_id)
+    gen = challenge_pack_generator.ChallengePackGenerator(
+        week,
+        slide_stack_id=None,
+        module_code=module_code,
+        lecturer_id=lecturer_id,
+    )
     result = await gen.generate()
     print("Generation result:")
     print(result)

--- a/scripts/generate_test.py
+++ b/scripts/generate_test.py
@@ -1,10 +1,14 @@
 import asyncio
-from app.features.challenges import claude_generator
-from app.features.challenges.claude_generator import _fetch_topic_context, generate_tier_preview, _call_bedrock
+from app.features.challenges import challenge_pack_generator
+from app.features.challenges.challenge_pack_generator import (
+    _fetch_topic_context,
+    generate_tier_preview,
+    _call_bedrock,
+)
 from app.features.challenges.templates.strings import get_fallback_payload
-from app.features.challenges.ai import bedrock_client
+from app.features.challenges.model_runtime import bedrock_client
 
-# Monkeypatch the Bedrock/Claude client to return the fallback payload
+# Monkeypatch the Bedrock model client to return the fallback payload
 async def _fake_invoke(prompt: str):
     # determine kind by simplistic check
     if "emerald" in prompt.lower():
@@ -18,11 +22,11 @@ async def _fake_invoke(prompt: str):
 
 async def main():
     week = 1
-    # Patch the bedrock invoke to avoid external calls
-    # claude_generator imported invoke_claude directly at module import time,
+    # Patch the Bedrock invoke to avoid external calls
+    # challenge_pack_generator imported invoke_model directly at module import time,
     # so replace the name in that module to ensure the fake is used.
     try:
-        claude_generator.invoke_claude = _fake_invoke
+        challenge_pack_generator.invoke_model = _fake_invoke
     except Exception:
         pass
     # fetch context

--- a/scripts/test_workflow.py
+++ b/scripts/test_workflow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Test script for the AWS Bedrock Claude challenge generation workflow.
-This script tests the complete workflow without making actual AWS API calls.
+Test script for the AWS Bedrock challenge generation workflow.
+This script exercises the complete workflow without making actual AWS API calls.
 """
 
 import asyncio
@@ -18,7 +18,7 @@ from app.features.topic_detections.topics.topic_service import topic_service
 async def test_workflow():
     """Test the complete workflow."""
 
-    print("=== Testing AWS Bedrock Claude Challenge Generation Workflow ===\n")
+    print("=== Testing AWS Bedrock Challenge Generation Workflow ===\n")
 
     # 1. Test configuration loading
     print("1. Testing configuration loading...")
@@ -138,7 +138,7 @@ async def test_workflow():
     print("5. Testing Bedrock client setup...")
     try:
         import boto3
-        from app.features.challenges.ai.bedrock_client import bedrock
+        from app.features.challenges.model_runtime.bedrock_client import bedrock
 
         print("   ✓ Boto3 bedrock client created")
         print(f"   ✓ Client region: {bedrock.meta.region_name}")
@@ -158,7 +158,7 @@ async def test_workflow():
     print("\nNext steps:")
     print("1. Set AWS credentials in environment variables")
     print("2. Add sample data to slide_extraction table")
-    print("3. Test actual Claude API calls")
+    print("3. Test actual model API calls")
     print("4. Test complete challenge generation and database insertion")
 
 


### PR DESCRIPTION
## Summary
- rename the challenge generation module and imports to use neutral naming and invoke_model
- tidy the achievements repository with docstrings and remove AI-related comments
- refresh the README wording to avoid AI terminology while keeping functionality unchanged

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app' / missing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d35f9b0d3083289aec55d8e16f2cef