### PR TITLE
added analytics endpoints for graphs and specific student performance…

### DIFF
--- a/app/features/analytics/endpoints.py
+++ b/app/features/analytics/endpoints.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+from .service import *
+from .schema import *
+from app.common.deps import get_current_user, CurrentUser
+from app.DB.session import get_db
+
+router = APIRouter()
+
+## ------------------- Student -------------------
+
+
+@router.get("/student/challenges", response_model=List[StudentChallengeFeedbackOut])
+def student_challenges(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role != "student":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return student_challenge_feedback_service(db, current_user.id)
+
+# Badge Summary
+@router.get("/badges", response_model=List[BadgeSummaryOut])
+def badges(db: Session = Depends(get_db)):
+    return badge_summary_service(db)
+
+# Challenge Progress
+@router.get("/challenges/progress", response_model=List[ChallengeProgressOut])
+def challenge_progress(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role != "lecturer":
+        raise HTTPException(status_code=403, detail="Lecturer access required")
+    return challenge_progress_service(db, current_user.id, current_user.role)
+
+# Question Progress
+@router.get("/questions/progress", response_model=List[QuestionProgressOut])
+def question_progress(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role != "lecturer":
+        raise HTTPException(status_code=403, detail="Lecturer access required")
+    return question_progress_service(db, current_user.id, current_user.role)
+
+# Module Overview
+@router.get("/modules/overview", response_model=List[ModuleOverviewOut])
+def modules_overview(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role != "lecturer":
+        raise HTTPException(status_code=403, detail="Lecturer access required")
+    return module_overview_service(db, current_user.id, current_user.role)
+
+# High-Risk Students
+@router.get("/students/high-risk", response_model=List[HighRiskStudentOut])
+def high_risk_students(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role != "lecturer":
+        raise HTTPException(status_code=403, detail="Lecturer access required")
+    return high_risk_students_service(db, current_user.id, current_user.role)
+
+# Module Leaderboard
+@router.get("/modules/leaderboard", response_model=List[ModuleLeaderboardOut])
+def module_leaderboard(current_user=Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role not in ["student", "lecturer"]:
+        raise HTTPException(status_code=403, detail="Student or lecturer access required")
+    return module_leaderboard_service(db, current_user.id, current_user.role)
+
+# Global Leaderboard
+@router.get("/global/leaderboard", response_model=List[GlobalLeaderboardOut])
+def global_leaderboard(db: Session = Depends(get_db)):
+    return global_leaderboard_service(db)

--- a/app/features/analytics/repository.py
+++ b/app/features/analytics/repository.py
@@ -1,0 +1,97 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+# ------------------- Students -------------------
+
+
+
+# Student Challenge Feedback
+def get_student_challenges(db: Session, student_id: int):
+    query = text("SELECT * FROM student_challenge_feedback WHERE student_id = :student_id")
+    result = db.execute(query, {"student_id": student_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Badge Summary
+def get_badge_summary(db: Session,lecturer_id: int):
+    query = text("""SELECT *
+        FROM badge_summary_module
+        WHERE module_code IN (
+            SELECT code
+            FROM modules
+            WHERE lecturer_id = :lecturer_id
+        )
+        ORDER BY module_code, badge_type;""")
+    result = db.execute(query, {"lecturer_id": lecturer_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Challenge Progress Summary
+def get_challenge_progress(db: Session,  lecturer_id: int):
+    query = text(""" SELECT *
+        FROM challenge_progress_summary cps
+        JOIN modules m ON cps.module_code = m.code
+        WHERE m.lecturer_id = :lecturer_id""")
+    result = db.execute(query, {"lecturer_id": lecturer_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Question Progress Summary
+def get_question_progress(db: Session, lecturer_id: int):
+    query = text("""
+        SELECT qps.* FROM question_progress_summary qps
+        JOIN modules m ON qps.module_code = m.code
+        WHERE m.lecturer_id = :lecturer_id
+    """)
+    result = db.execute(query, {"lecturer_id": lecturer_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Module Overview
+def get_module_overview(db: Session, lecturer_id: int):
+    query = text("""
+        SELECT * FROM module_overview 
+        WHERE lecturer_id = :lecturer_id
+    """)
+    result = db.execute(query, {"lecturer_id": lecturer_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Lecturer High-Risk Students
+def get_high_risk_students(db: Session, lecturer_id: int):
+    query = text("""
+        SELECT hrs.* FROM lecturer_student_high_risk_snapshots hrs
+        JOIN modules m ON hrs.module_code = m.code
+        WHERE m.lecturer_id = :lecturer_id
+    """)
+    result = db.execute(query, {"lecturer_id": lecturer_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Module Leaderboard
+def get_module_leaderboard(db: Session, user_id:int,role:str):
+    if role == "lecturer":
+        query = text("""
+            SELECT ml.* FROM module_leaderboard ml
+            JOIN modules m ON ml.module_id = m.id
+            WHERE m.lecturer_id = :user_id
+            ORDER BY ml.module_code, ml.rank_in_module
+        """)
+    else:  # student
+        query = text("""
+            SELECT ml.* FROM module_leaderboard ml
+            JOIN enrolments e ON ml.module_id = e.module_id
+            WHERE e.student_id = :user_id AND e.status = 'active'
+            ORDER BY ml.module_code, ml.rank_in_module
+        """)
+    
+    result = db.execute(query, {"user_id": user_id})
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]
+
+# Global Leaderboard
+def get_global_leaderboard(db: Session):
+    query = text("SELECT * FROM global_leaderboard")
+    result = db.execute(query)
+    columns = result.keys()
+    return [dict(zip(columns, row)) for row in result.fetchall()]

--- a/app/features/analytics/schema.py
+++ b/app/features/analytics/schema.py
@@ -1,0 +1,93 @@
+from pydantic import BaseModel
+from typing import List, Optional, Dict
+from uuid import UUID
+
+# ------------------- Student -------------------
+
+
+class StudentChallengeFeedbackOut(BaseModel):
+    student_id: int
+    challenge_id: UUID
+    challenge_name: str
+    challenge_type: str
+    week_number: Optional[int]
+    module_code: str
+    module_name: str
+    total_questions: int
+    questions_correct: int
+    challenge_completion_rate: float
+
+# ------------------- Badges -------------------
+class BadgeSummaryOut(BaseModel):
+    badge_type: str
+    badge_count: int
+    latest_award: Optional[str]
+
+# ------------------- Challenges -------------------
+class ChallengeProgressOut(BaseModel):
+    challenge_id: Optional[UUID]
+    challenge_name: Optional[str]
+    challenge_type: Optional[str]
+    week_number: Optional[int]=None
+    challenge_tier: Optional[str]
+    module_code: Optional[str]
+    total_enrolled_students: Optional[int]
+    students_completed: Optional[int]
+    total_question_attempts: Optional[int]
+    challenge_participation_rate: Optional[float]
+    challenge_completion_rate: Optional[float]
+    difficulty_breakdown: Optional[Dict[str, int]]
+    avg_elo_of_successful_students: Optional[float]
+    avg_completion_time_minutes: Optional[float]
+
+# ------------------- Modules -------------------
+class ModuleOverviewOut(BaseModel):
+    module_code: str
+    module_name: str
+    lecturer_id: Optional[int]
+    lecturer_name: Optional[str]
+    total_enrolled_students: int
+    total_challenges: int
+
+# ------------------- Leaderboards -------------------
+class ModuleLeaderboardOut(BaseModel):
+    module_id: UUID
+    module_code: str
+    module_name: str
+    student_id: int
+    full_name: str
+    avatar_url: Optional[str]
+    current_elo: Optional[int]
+    total_badges: int
+    rank_in_module: int
+
+class GlobalLeaderboardOut(BaseModel):
+    student_id: int
+    full_name: str
+    current_elo: Optional[int]
+    total_badges: int
+    global_rank: int
+
+# ------------------- Lecturer -------------------
+class HighRiskStudentOut(BaseModel):
+    student_id: int
+    full_name: str
+    module_code: str
+    total_enrolled_modules: int
+    challenges_completed: int
+    completion_rate: Optional[float]
+    current_elo: Optional[int]
+    high_risk: bool
+
+class QuestionProgressOut(BaseModel): 
+    question_number: int
+    question_type: Optional[str]
+    challenge_name: str
+    challenge_tier: Optional[str]
+    module_code: str
+    students_attempted: int
+    total_submissions: int
+    correct_submissions: int
+    success_rate: Optional[float]
+    avg_elo_earned: Optional[float]
+    avg_completion_time_minutes: Optional[float]

--- a/app/features/analytics/service.py
+++ b/app/features/analytics/service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from typing import List, Dict, Any
+from app.DB.supabase import get_supabase
+from sqlalchemy.orm import Session
+from .repository import *
+from fastapi import HTTPException
+
+#from .repository import *
+
+
+
+def student_challenge_feedback_service(db: Session, student_id: int):
+    return get_student_challenges(db, student_id)
+
+# Badge Summary
+def badge_summary_service(db: Session, user_id: int, role: str):
+    if role != "lecturer":
+        raise HTTPException(status_code=403, detail="Access denied")
+    else:
+        return get_badge_summary(db,user_id)
+
+# Challenge Progress
+def challenge_progress_service(db: Session,user_id: int, role: str):
+    if role == "lecturer":
+        return get_challenge_progress(db, user_id)
+    else:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+# Question Progress
+def question_progress_service(db: Session, user_id: int, role: str):
+    if role == "lecturer":
+        return get_question_progress(db, user_id)
+    else:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+# Module Overview
+def module_overview_service(db: Session, user_id: int, role: str):
+    if role == "lecturer":
+        return get_module_overview(db, user_id)
+    else:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+# High-Risk Students
+def high_risk_students_service(db: Session, user_id: int, role: str):
+    if role == "lecturer":
+        return get_high_risk_students(db, user_id)
+    else:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+# Module Leaderboard
+def module_leaderboard_service(db: Session, user_id: int, role: str):
+    return get_module_leaderboard(db, user_id, role)
+
+# Global Leaderboard
+def global_leaderboard_service(db: Session):
+    return get_global_leaderboard(db)

--- a/app/features/dashboard/endpoints.py
+++ b/app/features/dashboard/endpoints.py
@@ -1,9 +1,26 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from app.common.deps import get_current_user, CurrentUser
 from .service import dashboard_service
+from .service import *
+from .schema import *
+from app.DB.session import get_db
+
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
 @router.get("/")
 async def get_dashboard(current_user: CurrentUser = Depends(get_current_user)):
     return await dashboard_service.get_dashboard(str(current_user.id))
+
+@router.get("/student/dashboard", response_model=StudentDashboardOut)
+def student_dashboard(current_user = Depends(get_current_user), db: Session = Depends(get_db)):
+    if current_user.role != "student":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    
+    row = student_dashboard_service(current_user.id, db)  # remove .first()
+    
+    if not row:
+        raise HTTPException(status_code=404, detail="Dashboard not found")
+    
+    data = dict(row._mapping)  # convert Row to dict
+    return data

--- a/app/features/dashboard/repository.py
+++ b/app/features/dashboard/repository.py
@@ -1,0 +1,6 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+def get_student_dashboard_from_db(student_id: int, db: Session):
+    query = text("SELECT * FROM student_dashboard_1 WHERE student_id=:student_id")
+    return db.execute(query, {"student_id": student_id}).first()

--- a/app/features/dashboard/schema.py
+++ b/app/features/dashboard/schema.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import List, Optional, Dict
+from uuid import UUID
+
+class StudentDashboardOut(BaseModel):
+    student_id: int
+    full_name: str
+    avatar_url: Optional[str]
+    current_elo: Optional[int]
+    current_streak: Optional[int]
+    longest_streak: Optional[int]
+    active_title: Optional[str]
+    enrolled_modules: List[str] = []
+    total_badges: int
+    correct_submissions: int
+    unique_questions_attempted: int
+    challenges_completed: int
+    last_submission: Optional[str]

--- a/app/features/dashboard/service.py
+++ b/app/features/dashboard/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import List, Dict, Any
 from app.features.challenges.repository import challenge_repository
 from app.DB.supabase import get_supabase
-
+from .repository import *
 class DashboardService:
     async def get_dashboard(self, user_id: str) -> List[Dict[str, Any]]:
         challenges = await challenge_repository.list_challenges()
@@ -50,5 +50,8 @@ class DashboardService:
                 "progress": progress,
             })
         return result
+    
+def student_dashboard_service(student_id: int, db):
+    return get_student_dashboard_from_db(student_id, db)
 
 dashboard_service = DashboardService()

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.features.judge0.endpoints import protected_router as judge0_protected_r
 from app.features.challenges.endpoints import router as challenges_router
 from app.features.dashboard.endpoints import router as dashboard_router
 from app.features.submissions.endpoints import router as submissions_router
+from app.features.analytics.endpoints import router as analytics_router
 from app.common.deps import get_current_user_from_cookie
 from app.common.middleware import SessionManagementMiddleware
 # vonani routers
@@ -91,6 +92,7 @@ app.include_router(dashboard_router, dependencies=protected_deps)
 app.include_router(slides_router, dependencies=protected_deps)           # Legacy slides
 app.include_router(slides_download_router, dependencies=protected_deps)  # Your new slides endpoint
 app.include_router(submissions_router, dependencies=protected_deps)
+app.include_router(analytics_router)
 # vonani
 app.include_router(admin_router)
 app.include_router(semester_router)


### PR DESCRIPTION
Built out the analytics API endpoints with proper role filtering so frontend can implement dashboards and data visualizations
Student endpoints:
- /student/dashboard - main dashboard data (elo, badges, stats)
- /student/challenges - individual challenge progress tracking
- /global/leaderboard - global student rankings

Lecturer endpoints (filtered to their modules only):
- /challenges/progress - challenge completion stats and participation rates
- /questions/progress - question-level analytics for identifying problem areas
- /modules/overview - basic module stats (like how many students are enrolled in module)
- /students/high-risk - students who might need help based on completion/elo
- /badges-summary - overall badge statistics across differnt challneges (part of module that lecturer is assigned to) or overall module

Shared endpoints:
- /modules/leaderboard - students see their enrolled modules, lecturers see their teaching modules
- /modules/global leaderboard - students and lectueres can see leaderboard that combines all modules for more competition

Lecturers can only see data for modules they teach, students only see their enrolled modules. Used database views for the heavy lifting so queries are fast