### PR TITLE
Modified /skip, /clear endpoints for adjusting weeks for demo purpose

### DIFF
--- a/app/features/admin/schemas.py
+++ b/app/features/admin/schemas.py
@@ -143,3 +143,21 @@ class LecturerProfileResponse(BaseModel):
     avatar_url: Optional[str]
     phone: Optional[str]
     bio: Optional[str]
+
+
+#ADMIN CHANGE WEEK OFFSET SCHEMAS
+class DemoSkipRequest(BaseModel):
+    delta: int = Field(
+        ..., 
+        description="Number of weeks to skip (positive = forward, negative = backward)",
+        example=2
+    )
+
+
+class DemoResponse(BaseModel):
+    semester_id: str
+    semester_name: str
+    original_start_date: str
+    current_start_date: str
+    weeks_offset: int
+    message: str | None = None

--- a/app/features/semester/models.py
+++ b/app/features/semester/models.py
@@ -13,6 +13,7 @@ class Semester(Base):
     year = Column(Integer, nullable=False)
     term_name = Column(String, nullable=False)
     start_date = Column(DateTime, nullable=False)
+    original_start_date = Column(DateTime, nullable=False) 
     end_date = Column(DateTime, nullable=False)
     is_current = Column(Boolean, nullable=False, default=False)
     created_at = Column(DateTime, server_default=func.now(), nullable=False)


### PR DESCRIPTION
- Updated /demo/skip, /demo/clear endpoints to work directly with the start date in semesters table 
- Added `original_start_date` column to preserve true semester start dates and added DB trigger to auto-set `original_start_date` on semester insert
- Skipping weeks now adjusts semester.start_date based on original_start_date
- Clear endpoint resets semester.start_date to its original value (original_start_date)
- Removed the /demo/set endpoint

You can see example below where: Initial week -> skip by 2 weeks -> current week changes -> clear to go back to original week
<img width="1235" height="632" alt="clear_offset" src="https://github.com/user-attachments/assets/cc538d80-9d0a-4260-bd8f-0638b6d4b9ac" />
<img width="1545" height="263" alt="intital_week_before_offset" src="https://github.com/user-attachments/assets/62649ea3-0fa6-4851-baf1-42370e1c4944" />
<img width="1362" height="881" alt="skipping_by_2_weeks" src="https://github.com/user-attachments/assets/ba5c3362-36b6-4487-b491-7aa83914e4bf" />
<img width="1270" height="716" alt="updated_after_skipping" src="https://github.com/user-attachments/assets/82826460-be77-4825-849e-f39ba64d8f9d" />
