### PR TITLE
allow lecturers to access question bundle endpoint

### DIFF
--- a/app/features/submissions/endpoints.py
+++ b/app/features/submissions/endpoints.py
@@ -22,7 +22,7 @@ from app.features.achievements.schemas import CheckAchievementsRequest
 
 
 router = APIRouter(prefix="/submissions", tags=["submissions"], dependencies=[Depends(require_role("student"))])
-
+router_mixed = APIRouter(prefix="/submissions", tags=["submissions"])
 
 class BatchSubmissionsPayload(BaseModel):
     submissions: Dict[str, BatchSubmissionEntry]
@@ -105,7 +105,7 @@ async def quick_test_question_by_qid(
         raise HTTPException(status_code=400, detail=str(exc))
 
 
-@router.get(
+@router_mixed.get(
     "/challenges/{challenge_id}/questions/{question_id}/bundle",
     response_model=QuestionBundleSchema,
     summary="(debug) Return the question bundle including tests",
@@ -113,13 +113,8 @@ async def quick_test_question_by_qid(
 async def get_question_bundle_debug(
     challenge_id: str,
     question_id: str,
-    current_user: CurrentUser = Depends(get_current_user),
+    current_user: CurrentUser = Depends(require_role("student", "lecturer"))
 ):
-    try:
-        # student check ensures caller is authenticated
-        _ = int(current_user.id)
-    except Exception:
-        raise HTTPException(status_code=400, detail="invalid_student_number")
     try:
         return await submissions_service.get_question_bundle(challenge_id, question_id)
     except ValueError as exc:

--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ from app.features.judge0.endpoints import public_router as judge0_public_router
 from app.features.judge0.endpoints import protected_router as judge0_protected_router
 from app.features.challenges.endpoints import router as challenges_router, questions_router as challenge_questions_router
 from app.features.dashboard.endpoints import router as dashboard_router
-from app.features.submissions.endpoints import router as submissions_router
+from app.features.submissions.endpoints import router as submissions_router, router_mixed as submissions_router_mixed
 from app.features.analytics.endpoints import router as analytics_router
 from app.common.deps import get_current_user
 from app.common.middleware import SessionManagementMiddleware
@@ -137,6 +137,7 @@ app.include_router(slides_router, dependencies=protected_deps)
 app.include_router(slides_download_router, dependencies=protected_deps) 
 app.include_router(notifications_router, dependencies=protected_deps) 
 app.include_router(submissions_router, dependencies=protected_deps)
+app.include_router(submissions_router_mixed, dependencies=protected_deps)
 app.include_router(analytics_router)
 # vonani
 app.include_router(admin_router)


### PR DESCRIPTION
Added router_mixed to bypass student-only restriction on submissions router. The /bundle endpoint now allows both students and lecturers since FastAPI appends (not replaces) router-level dependencies
<img width="1789" height="687" alt="Screenshot 2025-10-07 201412" src="https://github.com/user-attachments/assets/065ab233-e35e-42ec-93b3-3c05e024a3ff" />
<img width="1834" height="684" alt="Screenshot 2025-10-07 201527" src="https://github.com/user-attachments/assets/41f16cb4-06bf-4e79-8c0a-f8f7a12dad0b" />
